### PR TITLE
test(jira/MBP-29): implement api for providing dfsp hostname and ip whitelist

### DIFF
--- a/gitlab_templates/switch-iac/.gitlab-ci.yml
+++ b/gitlab_templates/switch-iac/.gitlab-ci.yml
@@ -618,6 +618,14 @@ Create Gateway Cluster:
     - exit `kubectl --kubeconfig=admin-gateway.conf -n mojaloop get pod bof-report-tests --output="jsonpath={.status.containerStatuses[].state.terminated.exitCode}"`
   when: manual
 
+7. Run MCM Tests:
+  stage: "Run Tests"
+  script:
+    - helm --kubeconfig=admin-gateway.conf test connection-manager -n mcm || true
+    - kubectl --kubeconfig=admin-gateway.conf -n mcm logs connection-manager-api-test
+    - exit `kubectl --kubeconfig=admin-gateway.conf -n mcm get pod connection-manager-api-test --output="jsonpath={.status.containerStatuses[].state.terminated.exitCode}"`
+  when: manual
+
 1. Run External PM4ML Onboarding:
   stage: "Maintain Platform"
   script:

--- a/gitlab_templates/switch-iac/workbench-config-13.json
+++ b/gitlab_templates/switch-iac/workbench-config-13.json
@@ -5,7 +5,7 @@
   "AWS_DEFAULT_REGION": "eu-west-1",
   "wso2_mysql_repo_version": "v1.0.0",
   "helm_esp_version": "11.0.1",
-  "helm_mcm_connection_manager_version": "0.5.19",
+  "helm_mcm_connection_manager_version": "0.5.26",
   "helm_nginx_version": "3.40.0",
   "helm_mojaloop_version": "13.1.1",
   "helm_mojaloop_simulator_version": "12.0.0",


### PR DESCRIPTION
test(jira/MBP-29): implement api for providing dfsp hostname and ip whitelist - https://modusbox.atlassian.net/browse/MBP-29
- added `7. Run MCM Tests` job to `Run Tests` stage
- bumped mcm helm chart from v0.5.22 -> v0.5.23